### PR TITLE
Change slides size and h1 size

### DIFF
--- a/KotlinOverview.html
+++ b/KotlinOverview.html
@@ -17,6 +17,7 @@ table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
 table.sourceCode { width: 100%; line-height: 100%; }
 td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
 .reveal pre code { font-size: 1.3em; }
+body .reveal h1 { font-size: 3em; }
 td.sourceCode { padding-left: 5px; }
 code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
 code > span.dt { color: #902000; } /* DataType */

--- a/reveal.js/js/reveal.js
+++ b/reveal.js/js/reveal.js
@@ -39,7 +39,7 @@
 
 			// The "normal" size of the presentation, aspect ratio will be preserved
 			// when the presentation is scaled to fit different resolutions
-			width: 960,
+			width: 1024,
 			height: 700,
 
 			// Factor of the display size that should remain empty around the content


### PR DESCRIPTION
It seems the width and margins of the `code` sections is define in Javascript and later injected to the html dynamically. I hope this works for you.

In the reveal.js file you can also modify the margin if you feel a little bit constrained even at that size.